### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 A Model Context Protocol (MCP) server that enables external keyboard and mouse input injection into Scenic GUI applications.
 
+<a href="https://glama.ai/mcp/servers/@scenic-contrib/scenic_mcp_experimental">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@scenic-contrib/scenic_mcp_experimental/badge" alt="Scenic MCP server" />
+</a>
+
 ## Features
 
 - **Keyboard Input**: Send text and special keys to Scenic applications


### PR DESCRIPTION
This PR adds a badge for the [Scenic MCP](https://glama.ai/mcp/servers/@scenic-contrib/scenic_mcp_experimental) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@scenic-contrib/scenic_mcp_experimental">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@scenic-contrib/scenic_mcp_experimental/badge" alt="Scenic MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.